### PR TITLE
Fix #105 fix error 500 when downloading Youtube videos

### DIFF
--- a/src/commands/utils/downloadYoutube.js
+++ b/src/commands/utils/downloadYoutube.js
@@ -20,7 +20,7 @@ import {
  * @param {string} title title of atom
  * @param {string} format youtube-dl quality setting (eg. best)
  */
-export default function downloadYoutube(videoId, outputPath, prefix, title, format = 'best[height=1080]/best[height=720]/best[height=480]/best[height=360]') {
+export default function downloadYoutube(videoId, outputPath, prefix, title, format = 'best[height=720]/best[height=480]/best[height=360]') {
   return new Promise(async (resolve, reject) => {
     if (!videoId) {
       resolve(null);


### PR DESCRIPTION
Fix for the issue "Error Status code 500".

# Description
   It's an `Server side youtube error` that it dosent support the resolution asked for, and youtube-dl is unable to pass four different resolution at a time so deleted the unnessory one .

Fixes #105 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Results
**Before Fix**
![Udacimak error](https://user-images.githubusercontent.com/34301492/78752867-80202d80-7992-11ea-82f5-77d0b80323e0.png)

**After Fix**
![Udacimak Fix](https://user-images.githubusercontent.com/34301492/78752870-81e9f100-7992-11ea-98bc-f5f02efc9b81.png)


# How Has This Been Tested?

- [x] Test A
  Tested on local workspace and it worked like charm without throwing any issue or error.

# Configurations

- OS: [Windows 10 Home]
- Node version: (v12.16.1)
- npm version: (6.13.4)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
