### PR TITLE
removed prompt from dependencies list

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "ora": "^3.0.0",
     "pkginfo": "^0.4.1",
     "progress-stream": "^2.0.0",
-    "prompt": "^1.0.0",
     "request": "^2.88.0",
     "request-progress": "^3.0.0",
     "rimraf": "^2.6.2",


### PR DESCRIPTION
# Description

I forget to remove the prompt module from the list of dependencies. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

the build was tested (babel src --out-dir lib --copy-files), and the command login and listnd were also tested successfully

