### PR TITLE
Fix rendering defaultPath for jupyter workspace files

### DIFF
--- a/src/commands/render/functions/atoms/createHtmlWorkspaceAtom.js
+++ b/src/commands/render/functions/atoms/createHtmlWorkspaceAtom.js
@@ -27,7 +27,9 @@ export default async function createHtmlWorkspaceAtom(atom) {
     const { conf } = configuration.blueprint;
     if (conf) {
       // Jupyter workspace usually has defaultPath
-      if (conf.defaultPath) ({ defaultPath } = conf.defaultPath);
+      if (conf.defaultPath) {
+        ({ defaultPath } = conf);
+      }
       // Coding workspace usually has openFiles
       if (conf.openFiles && conf.openFiles.length) {
         ({ openFiles } = conf.openFiles);


### PR DESCRIPTION
# Description

Workspace file `defaultPath`is collected from `configuration.blueprint.conf.defaultPath` instead of `configuration.blueprint.conf.defaultPath.defaultPath`

Fixes #151

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- I rendered udacity nd880 to check that the workspace render shows the _Default file path_ correctly:

![Screenshot 2020-05-24 at 20 43 46](https://user-images.githubusercontent.com/965762/82762138-9b8aaf00-9dff-11ea-9c83-a6fd9cc563d0.png)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
